### PR TITLE
Set auth cookie max_age, so it doesn't clear when browser closes. Als…

### DIFF
--- a/FCMS/security.py
+++ b/FCMS/security.py
@@ -11,6 +11,7 @@ class MyAuthPolicy(AuthTktAuthenticationPolicy):
             return user.id
         return None
 
+
 def get_user(request):
     user_id = request.unauthenticated_userid
     if user_id is not None:
@@ -23,7 +24,8 @@ def includeme(config):
     settings = config.get_settings()
     authn_policy = MyAuthPolicy(
         settings['auth_secret'],
-        hashalg='sha512',
+        hashalg='sha512', timeout=1200,
+        max_age=31557600, reissue_time=120
     )
     config.set_authentication_policy(authn_policy)
     config.set_authorization_policy(ACLAuthorizationPolicy())


### PR DESCRIPTION
…o set a timeout/reissue_time for added security against session hijacking.