### PR TITLE
Prevent not sending a webhook on market update by requiring message to be added to input box

### DIFF
--- a/FCMS/templates/my_carrier_subview.jinja2
+++ b/FCMS/templates/my_carrier_subview.jinja2
@@ -604,8 +604,8 @@
 
                           {% endfor %}
                             <tr>
-                                <td><label for="market_message">(Optional) Message</label>
-                                    <div class="input-group-text"><input class="form-control"  type="text" name="message" id="market_message" placeholder="Type your message"></div></td><td>
+                                <td><label for="market_message">Message</label>
+                                    <div class="input-group-text"><input class="form-control"  type="text" name="message" id="market_message" placeholder="Type your message" required></div></td><td>
                                     <input type="hidden" name="market-update" value="market-update"><br>
                                     <div class="input-group-btn"><button type="submit" class="btn btn-block bg-gradient-primary" value="Send market update">Send market update</button></div>
 


### PR DESCRIPTION
Hi,

I've made a very crude (and untested, I will add) edit to the market page, simply adding the required tag in the HTML, to prevent sending an update which would not trigger the sent of a webhook.

Ideally I should've gone and fixed the underlying issue, as this is just a bandaid, but I figured this is better than nothing, as I unfortunately am not confident in implementing that fix myself.

Thanks!